### PR TITLE
fix integer bug when start or end equals 0

### DIFF
--- a/lib/integer.js
+++ b/lib/integer.js
@@ -38,8 +38,8 @@
     params: function(options) {
       options = options || {};
 
-      this.start = options.start || this.start;
-      this.end   = options.end || this.end;
+      this.start = utils.isNumeric(options.start) ? options.start : this.start;
+      this.end   = utils.isNumeric(options.end) ? options.end : this.end;
 
       return {
         start: this.start,

--- a/tests/lib/test-date.js
+++ b/tests/lib/test-date.js
@@ -48,7 +48,7 @@
         date = rDate({start: 1879, end: 2013});
         (date.start).should.equal(1879);
         (date.end).should.equal(2013);
-        should(date.format).not.exist;
+        should.not.exist(date.format);
         (date.isUTC).should.equal(false);
 
         date = rDate({start: 1880, end: 2032, format: "YYYY-DD", isUTC: true});

--- a/tests/util/test-utils.js
+++ b/tests/util/test-utils.js
@@ -26,6 +26,7 @@
         isNumeric(123.123).should.be.true;
 
         isNumeric("").should.be.false;
+        isNumeric(undefined).should.be.false;
         isNumeric("12!3").should.be.false;
         isNumeric({
           name: "levi"


### PR DESCRIPTION
In integer, when start or end equals 0, in `params` will set the this.start & this.end to `-2000000000` &  `2000000000`.
I just use utils.isNumeric to fix this bug.
Please review.
Thanks